### PR TITLE
[SPARTA-1987] Fix for requests with queries

### DIFF
--- a/common/src/main/scala/com/stratio/tikitakka/common/util/HttpRequestUtils.scala
+++ b/common/src/main/scala/com/stratio/tikitakka/common/util/HttpRequestUtils.scala
@@ -64,7 +64,7 @@ trait HttpRequestUtils extends LogUtils {
     val resourceQuery = "(?<=\\?).*".r.findFirstIn(resource)
     val resourceWithoutQuery = ".*(?=\\?)".r.findFirstIn(resource)
     val uri = Uri.from(host = host,
-      path = resourceWithoutQuery.fold(req){ res => req.concat(res)},
+      path = resourceWithoutQuery.fold(req.concat(resource)){ res => req.concat(res)},
       queryString = resourceQuery
     )
     val uriCompleted = (port match {

--- a/common/src/test/scala/com/stratio/tikitakka/common/util/HttpRequestUtilsTest.scala
+++ b/common/src/test/scala/com/stratio/tikitakka/common/util/HttpRequestUtilsTest.scala
@@ -41,5 +41,13 @@ class HttpRequestUtilsTest extends TestKit(ActorSystem("HttpRequestUtils"))
         actualReq._2.toString() should equal (baseUrl.concat("/"+resource))
       }
     }
+    "passed a resource without query" should{
+      "create a correct url" in {
+        val baseUrl = "https://megadev.labs.stratio.com/service/marathon"
+        val resource = "v2/groups/anyApp/instanceName/WithWorkflows"
+        val actualReq = createRequest(baseUrl, resource, HttpMethods.GET, None, Seq.empty[HttpCookie])
+        actualReq._2.toString() should equal (baseUrl.concat("/"+resource))
+      }
+    }
   }
 }

--- a/common/src/test/scala/com/stratio/tikitakka/common/util/HttpRequestUtilsTest.scala
+++ b/common/src/test/scala/com/stratio/tikitakka/common/util/HttpRequestUtilsTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.tikitakka.common.util
+
+import java.net.HttpCookie
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpMethods
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
+import akka.testkit.TestKit
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{ShouldMatchers, WordSpec, WordSpecLike}
+
+@RunWith(classOf[JUnitRunner])
+class HttpRequestUtilsTest extends TestKit(ActorSystem("HttpRequestUtils"))
+  with ShouldMatchers with WordSpecLike with HttpRequestUtils {
+
+  implicit val testSystem = ActorSystem("test")
+  implicit val actorMaterializer = ActorMaterializer(ActorMaterializerSettings(system))
+
+  "HttpRequestUtils.createRequest" when {
+    "passed a resource with a query on it" should {
+      "create a correct url" in {
+        val baseUrl = "https://megadev.labs.stratio.com/service/marathon"
+        val resource = "v2/apps?id=anyApp/instanceName/WithWorkflows"
+        val actualReq = createRequest(baseUrl, resource, HttpMethods.GET, None, Seq.empty[HttpCookie])
+        actualReq._2.toString() should equal (baseUrl.concat("/"+resource))
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <scala.version>2.11</scala.version>
         <scala.lib.version>${scala.version}.8</scala.lib.version>
         <akka.version>2.4.8</akka.version>
-        <play.libs.version>2.5.8</play.libs.version>
+        <play.libs.version>2.6.9</play.libs.version>
         <scalaz.version>7.2.8</scalaz.version>
         <typesafe.config.version>1.3.0</typesafe.config.version>
         <slf4j.version>1.7.7</slf4j.version>


### PR DESCRIPTION
As of the latest RC, if we pass a request with a query in it the URL will be encoded so that ? becomes %3F.

E.g.the request _v2/apps?id=sparta/instanceName/workflows_ will be encoded inside the HttpRequest for doRequest in HttpRequestUtils as `https://megadev.labs.stratio.com/marathon/v2/apps`**%3F**`id=sparta/instanceName/workflows` instead of `https://megadev.labs.stratio.com/marathon/v2/apps`**?**`id=sparta/instanceName/workflows`

Therefore in this PR we added the search and retrieval of a query in the resource part while building the URI to be passed to the HttpRequest.

Unit tests are included too.
